### PR TITLE
CORS from Apollo Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "devDependencies": {
     "@types/bcrypt": "^2.0.0",
-    "@types/cors": "^2.8.4",
     "@types/helmet": "^0.0.38",
     "@types/jsonwebtoken": "^7.2.8",
     "@types/morgan": "^1.7.35",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,4 @@
 import cookieParser from "cookie-parser";
-import cors from "cors";
 import { NextFunction, Response } from "express";
 import { GraphQLServer } from "graphql-yoga";
 import helmet from "helmet";
@@ -25,7 +24,6 @@ class App {
   }
 
   private middlewares = (): void => {
-    this.app.express.use(cors());
     this.app.express.use(logger("dev"));
     this.app.express.use(helmet());
     this.app.express.use(cookieParser());

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,11 @@ const GRAPHQL_ENDPOINT: string = "/graphql";
 const appOptions: Options = {
   port: PORT,
   playground: PLAYGROUND_ENDPOINT,
-  endpoint: GRAPHQL_ENDPOINT
+  endpoint: GRAPHQL_ENDPOINT,
+  cors: {
+    credentials: true,
+    origin: true
+  }
 };
 
 const handleAppStart = () => console.log(`Server is Listening on ${PORT}`);


### PR DESCRIPTION
Man, I had an error for like three days that was killing me, the problem was that I was configuring the CORS from the middleware without knowing that they where gonna be rewritten by the CORS configuration of the GraphQL Yoga configuration.

This is relevant for when somebody is using NextJS since the authentication is shared by cookies.