### PR TITLE
fix entity.User & resolvers.EmailSignUp

### DIFF
--- a/src/api/User/EmailSignUp/EmailSignUp.resolvers.ts
+++ b/src/api/User/EmailSignUp/EmailSignUp.resolvers.ts
@@ -21,7 +21,13 @@ const resolvers: Resolvers = {
             user: null
           };
         } else {
-          const user = await User.create({ ...args }).save();
+          const user = new User();
+          user.email = email;
+          await user.setPassword(password);
+          user.firstName = firstName;
+          user.lastName = lastName;
+          await user.save();
+
           if (user) {
             return {
               ok: true,

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -2,8 +2,6 @@ import bcrypt from "bcrypt";
 import { IsEmail } from "class-validator";
 import {
   BaseEntity,
-  BeforeInsert,
-  BeforeUpdate,
   Column,
   CreateDateColumn,
   Entity,
@@ -45,13 +43,9 @@ class User extends BaseEntity {
     return bcrypt.compare(password, this.password);
   }
 
-  @BeforeInsert()
-  @BeforeUpdate()
-  async savePassword(): Promise<void> {
-    if (this.password) {
-      const hashedPassword = await this.hashPassword(this.password);
-      this.password = hashedPassword;
-    }
+  public async setPassword(password: string): Promise<void> {
+    const hashedPassword = await this.hashPassword(password);
+    this.password = hashedPassword;
   }
   private hashPassword(password: string): Promise<string> {
     return bcrypt.hash(password, BCRYPT_ROUNDS);


### PR DESCRIPTION
*Issue*
@BeforeInsert, @BeforeUpdate cause the unnecessary hashing of the existing saved password whenever the user data gets changed. It results that a user can not sign in after user data is changed such as profile change, etc.

*Proposed Solution*
- Removing decorators @BeforeInsert, @BeforeUpdate
- Make a new public class method `setPassword(password)` to set a hashed password in user instance.